### PR TITLE
Added update to correctly link to packages included using npm link

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,10 +43,9 @@ function createImporter(options) {
     //  to...
     //  "/Users/me/src/my-project/node_modules/node-module/stuff"
     var parts = url.replace(prefixRegex, '').split('/')
-    var packageName = parts[0];
-    var packagePathRegex = new RegExp('.*/node_modules/(?:[^/]+/)*' + packageName);
-    parts[0] = require.resolve(packageName + '/package.json').match(packagePathRegex)[0];
-    var next = parts.join('/');
+    var packagePath = require.resolve(parts[0] + "/package.json").replace("/package.json", "")
+    parts.shift(0) // drop package name since we have base path
+    var next = packagePath + "/" + parts.join("/");
 
     debug('Replaced with ' + next);
 


### PR DESCRIPTION
I'm working on a pattern library that has been included in my project using `npm link`. The importer was throwing an error since the actual location of the package was in a different repo (dir). Updated the logic in the locator so that it doesn't assume the package is in the local `node_module` directory

Thanks for this project. Just started my first react app on create-react-app and this lets me avoid doing `npm eject` for a while. Cheers.